### PR TITLE
docs: fix incorrect port-forwarding command in agent quick reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,10 @@ tnr status           # List instances with status
 tnr connect <id>     # SSH into an instance
 tnr scp <src> <dst>  # Transfer files
 tnr delete <id>      # Delete an instance
-tnr port <id> <port> # Forward a port
+tnr ports forward <id> --add <port> # Forward a port
 ```
 
-Instance IDs are integers. Add `--json` for scripted/non-interactive usage.
+Instance IDs are integers (also accept UUID or name). Add `--json` for scripted/non-interactive usage.
 
 ## Development
 


### PR DESCRIPTION
The CLI Quick Reference in `AGENTS.md` (which `CLAUDE.md` symlinks to) listed:

```
tnr port <id> <port>    # Forward a port
```

That command does not exist. The correct invocation is:

```
tnr ports forward <id> --add <port>
```

Also updated the note about instance identifiers: the CLI accepts integer ID, UUID, or name (see `findInstance()` in `cmd/helpers.go`).